### PR TITLE
Remove AdSense key

### DIFF
--- a/tomo_blogger_template.xml
+++ b/tomo_blogger_template.xml
@@ -1553,7 +1553,7 @@
 
       <script async='async' src='https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js?skin=sons-of-obsidian'/>
 
-    <script async='async' crossorigin='anonymous' src='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2348922508571726'/>
+    <script async='async' crossorigin='anonymous' src='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXX'/>
     
     </head>
     <body>


### PR DESCRIPTION
## Summary
- replace AdSense client ID with a placeholder to hide the key

## Testing
- `grep -n "ca-pub" -n tomo_blogger_template.xml`

------
https://chatgpt.com/codex/tasks/task_e_686a748be66c833295e568dedc093931